### PR TITLE
mettre à jour le lien vers la documentation

### DIFF
--- a/AddIn/ArcGisProEspaceCollaboratif/ArcGisProEspaceCollaboratif/Help.cs
+++ b/AddIn/ArcGisProEspaceCollaboratif/ArcGisProEspaceCollaboratif/Help.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using static System.Net.WebRequestMethods;
 
 namespace ArcGisProEspaceCollaboratif
 {
@@ -20,11 +21,19 @@ namespace ArcGisProEspaceCollaboratif
         {
             logger.Debug("Clic sur le bouton d'ouverture du manuel de l'add-in Espace collaboratif");
 
-            string file = string.Format("{0}{1}", Helper.EspaceCollaboratifDirectoryFiles, Helper.name_file_manuel);
-            Process fileopener = new ();
-            fileopener.StartInfo.FileName = "explorer";
-            fileopener.StartInfo.Arguments = string.Format("\"{0}\"", file);
-            fileopener.Start();
+            string url = Helper.url_manuel;
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = url,
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.Error("Erreur lors de l'ouverture de l'URL : " + ex.Message);
+            }
         }
     }
 

--- a/AddIn/ArcGisProEspaceCollaboratif/ArcGisProEspaceCollaboratif/Helper.cs
+++ b/AddIn/ArcGisProEspaceCollaboratif/ArcGisProEspaceCollaboratif/Helper.cs
@@ -30,7 +30,8 @@ namespace ArcGisProEspaceCollaboratif
         public const string name_file_espaceco_xml = "espaceco.xml";
         public const string name_file_extensions = "formats.txt";
         public const string name_file_about_status = "AboutStatusResponse.txt";
-        public const string name_file_manuel = "ENR_Espace_co_Add-in_ArcGIS_Pro_2_0_0.pdf";
+
+        public const string url_manuel = "https://ignf.github.io/espace-collaboratif-arcgis-addin/";
 
         public const string name_layer_Signalement = "Signalement";
         public const string name_layer_Croquis_Polygone = "Croquis_EC_Polygone";


### PR DESCRIPTION
Changement du lien vers la doc pour pointer vers  https://ignf.github.io/espace-collaboratif-arcgis-addin/